### PR TITLE
Fixed bug with time counting and added a method to retrieve the time elapsed

### DIFF
--- a/src/gr/antoniom/chronometer/Chronometer.java
+++ b/src/gr/antoniom/chronometer/Chronometer.java
@@ -1,5 +1,6 @@
 package gr.antoniom.chronometer;
 
+
 /*
  * The Android chronometer widget revised so as to count milliseconds
  */
@@ -29,6 +30,8 @@ public class Chronometer extends TextView {
 
     private static final int TICK_WHAT = 2;
 
+    private long timeElapsed;
+    
     public Chronometer(Context context) {
         this (context, null, 0);
     }
@@ -68,6 +71,7 @@ public class Chronometer extends TextView {
     }
 
     public void start() {
+        mBase = SystemClock.elapsedRealtime();
         mStarted = true;
         updateRunning();
     }
@@ -98,7 +102,7 @@ public class Chronometer extends TextView {
     }
 
     private synchronized void updateText(long now) {
-        long timeElapsed = now - mBase;
+        timeElapsed = now - mBase;
         
         DecimalFormat df = new DecimalFormat("00");
         
@@ -157,4 +161,9 @@ public class Chronometer extends TextView {
             mOnChronometerTickListener.onChronometerTick(this);
         }
     }
+
+	public long getTimeElapsed() {
+		return timeElapsed;
+	}
+    
 }


### PR DESCRIPTION
There was a bug where the time counting wasn't starting when calling
start() but instead when the view was created. This caused issues when
you didn't wanna start your chronometer right away.
I also added a method do retrieve the time elapsed.
