### PR TITLE
Updated start() method

### DIFF
--- a/src/gr/antoniom/chronometer/Chronometer.java
+++ b/src/gr/antoniom/chronometer/Chronometer.java
@@ -71,7 +71,6 @@ public class Chronometer extends TextView {
     }
 
     public void start() {
-        mBase = SystemClock.elapsedRealtime();
         mStarted = true;
         updateRunning();
     }


### PR DESCRIPTION
The chronometer would ignore whatever value was in setBase() and instead would always set the base whenever start() was called.